### PR TITLE
Remove empty space and $git_info from prompt

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -13,6 +13,6 @@ function fish_prompt
       or echo "$red➜ "
   end) " $cyan"(basename (prompt_pwd)) (begin
     echo "$blue git:("$normal(git_branch_name)"$blue)"
-    git_is_touched; and echo "$git_info$yellow ✗"
+    git_is_touched; and echo "$yellow✗"
   end)"$normal "
 end


### PR DESCRIPTION
This PR removes the unnecessary space before the "✗" mark:

Before:
``` txt
➜  wa-russell git:(master)  ✗
```

After:
``` txt
➜  wa-russell git:(master) ✗
```